### PR TITLE
fix: navigation url error - within blog view

### DIFF
--- a/leannes_learners_data/urls.py
+++ b/leannes_learners_data/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
     path('pass_plus', views.PassPlusPage.as_view(), name='pass_plus'),
     path('prices', views.PricesPage.as_view(), name='prices'),
     path('like/<slug:slug>', views.LikePost.as_view(), name='like'),
-    path('<slug:slug>/', views.BlogDetail.as_view(), name='blog_post_view'),
+    path('<slug:slug>', views.BlogDetail.as_view(), name='blog_post_view'),
 
     # path('URL', views.VIEWS-FORM-CLASS-NAME.as_view(), name='PAGE-NAME'),
     ]

--- a/leannes_learners_data/views.py
+++ b/leannes_learners_data/views.py
@@ -42,7 +42,6 @@ class BlogDetail(View):
             },
         )
 
-    # def BlogPost(self, request, slug, *args, **kwargs):
     def post(self, request, slug, *args, **kwargs):
         queryset = Blog.objects.filter(status=1)
         blog = get_object_or_404(queryset, slug=slug)


### PR DESCRIPTION
fix: navigation url error - within blog view

URL in correctly had / after causing the navigation to always look at the blog page as the root for navigation purposes.